### PR TITLE
Marshmallow Update

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -52,7 +52,7 @@ jsonpickle==1.2
 jsonpointer==2.0
 jsonschema==2.6.0
 markupsafe==1.1.1
-marshmallow==2.19.5
+marshmallow==3.6.0
 mccabe==0.6.1
 mock==3.0.5
 more-itertools==7.0.0 ; python_version > '2.7'

--- a/strata_period_method.py
+++ b/strata_period_method.py
@@ -3,7 +3,7 @@ import os
 
 import pandas as pd
 from es_aws_functions import general_functions
-from marshmallow import Schema, fields, EXCLUDE
+from marshmallow import EXCLUDE, Schema, fields
 
 
 class EnvironmentSchema(Schema):

--- a/strata_period_method.py
+++ b/strata_period_method.py
@@ -1,20 +1,34 @@
 import logging
 import os
 
-import marshmallow
 import pandas as pd
 from es_aws_functions import general_functions
+from marshmallow import Schema, fields, EXCLUDE
 
 
-class EnvironmentSchema(marshmallow.Schema):
-    strata_column = marshmallow.fields.Str(required=True)
-    value_column = marshmallow.fields.Str(required=True)
+class EnvironmentSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating environment params: {e}")
+        raise ValueError(f"Error validating environment params: {e}")
+
+    strata_column = fields.Str(required=True)
+    value_column = fields.Str(required=True)
 
 
-class RuntimeSchema(marshmallow.Schema):
-    data = marshmallow.fields.Str(required=True)
-    region_column = marshmallow.fields.Str(required=True)
-    survey_column = marshmallow.fields.Str(required=True)
+class RuntimeSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating runtime params: {e}")
+        raise ValueError(f"Error validating runtime params: {e}")
+
+    data = fields.Str(required=True)
+    region_column = fields.Str(required=True)
+    survey_column = fields.Str(required=True)
 
 
 def lambda_handler(event, context):
@@ -36,15 +50,9 @@ def lambda_handler(event, context):
         # Because it is used in exception handling
         run_id = event["RuntimeVariables"]["run_id"]
 
-        environment_variables, errors = EnvironmentSchema().load(os.environ)
-        if errors:
-            logger.error(f"Error validating environment params: {errors}")
-            raise ValueError(f"Error validating environment params: {errors}")
+        environment_variables = EnvironmentSchema().load(os.environ)
 
-        runtime_variables, errors = RuntimeSchema().load(event["RuntimeVariables"])
-        if errors:
-            logger.error(f"Error validating runtime params: {errors}")
-            raise ValueError(f"Error validating runtime params: {errors}")
+        runtime_variables = RuntimeSchema().load(event["RuntimeVariables"])
 
         logger.info("Validated parameters.")
 

--- a/strata_period_method.py
+++ b/strata_period_method.py
@@ -3,7 +3,7 @@ import os
 
 import pandas as pd
 from es_aws_functions import general_functions
-from marshmallow import EXCLUDE, Schema, fields
+from marshmallow import EXCLUDE, INCLUDE, Schema, fields
 
 
 class EnvironmentSchema(Schema):
@@ -20,7 +20,7 @@ class EnvironmentSchema(Schema):
 
 class RuntimeSchema(Schema):
     class Meta:
-        unknown = EXCLUDE
+        unknown = INCLUDE
 
     def handle_error(self, e, data, **kwargs):
         logging.error(f"Error validating runtime params: {e}")

--- a/strata_period_method.py
+++ b/strata_period_method.py
@@ -3,7 +3,7 @@ import os
 
 import pandas as pd
 from es_aws_functions import general_functions
-from marshmallow import EXCLUDE, INCLUDE, Schema, fields
+from marshmallow import EXCLUDE, Schema, fields
 
 
 class EnvironmentSchema(Schema):
@@ -20,7 +20,7 @@ class EnvironmentSchema(Schema):
 
 class RuntimeSchema(Schema):
     class Meta:
-        unknown = INCLUDE
+        unknown = EXCLUDE
 
     def handle_error(self, e, data, **kwargs):
         logging.error(f"Error validating runtime params: {e}")

--- a/strata_period_wrangler.py
+++ b/strata_period_wrangler.py
@@ -5,7 +5,7 @@ import os
 import boto3
 import pandas as pd
 from es_aws_functions import aws_functions, exception_classes, general_functions
-from marshmallow import EXCLUDE, Schema, fields
+from marshmallow import EXCLUDE, INCLUDE, Schema, fields
 
 
 class EnvironmentSchema(Schema):
@@ -26,7 +26,7 @@ class EnvironmentSchema(Schema):
 
 class RuntimeSchema(Schema):
     class Meta:
-        unknown = EXCLUDE
+        unknown = INCLUDE
 
     def handle_error(self, e, data, **kwargs):
         logging.error(f"Error validating runtime params: {e}")

--- a/strata_period_wrangler.py
+++ b/strata_period_wrangler.py
@@ -5,7 +5,7 @@ import os
 import boto3
 import pandas as pd
 from es_aws_functions import aws_functions, exception_classes, general_functions
-from marshmallow import EXCLUDE, INCLUDE, Schema, fields
+from marshmallow import EXCLUDE, Schema, fields
 
 
 class EnvironmentSchema(Schema):
@@ -26,7 +26,7 @@ class EnvironmentSchema(Schema):
 
 class RuntimeSchema(Schema):
     class Meta:
-        unknown = INCLUDE
+        unknown = EXCLUDE
 
     def handle_error(self, e, data, **kwargs):
         logging.error(f"Error validating runtime params: {e}")

--- a/strata_period_wrangler.py
+++ b/strata_period_wrangler.py
@@ -5,10 +5,17 @@ import os
 import boto3
 import pandas as pd
 from es_aws_functions import aws_functions, exception_classes, general_functions
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, EXCLUDE
 
 
 class EnvironmentSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating environment params: {e}")
+        raise ValueError(f"Error validating environment params: {e}")
+
     bucket_name = fields.Str(required=True)
     checkpoint = fields.Str(required=True)
     method_name = fields.Str(required=True)
@@ -18,6 +25,13 @@ class EnvironmentSchema(Schema):
 
 
 class RuntimeSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+    def handle_error(self, e, data, **kwargs):
+        logging.error(f"Error validating runtime params: {e}")
+        raise ValueError(f"Error validating runtime params: {e}")
+
     period = fields.Str(required=True)
     in_file_name = fields.Str(required=True)
     incoming_message_group_id = fields.Str(required=True)
@@ -57,15 +71,9 @@ def lambda_handler(event, context):
         # Set up clients
         var_lambda = boto3.client("lambda", region_name="eu-west-2")
 
-        environment_variables, errors = EnvironmentSchema().load(os.environ)
-        if errors:
-            logger.error(f"Error validating environment params: {errors}")
-            raise ValueError(f"Error validating environment params: {errors}")
+        environment_variables = EnvironmentSchema().load(os.environ)
 
-        runtime_variables, errors = RuntimeSchema().load(event["RuntimeVariables"])
-        if errors:
-            logger.error(f"Error validating runtime params: {errors}")
-            raise ValueError(f"Error validating runtime params: {errors}")
+        runtime_variables = RuntimeSchema().load(event["RuntimeVariables"])
 
         logger.info("Validated parameters.")
 

--- a/strata_period_wrangler.py
+++ b/strata_period_wrangler.py
@@ -5,7 +5,7 @@ import os
 import boto3
 import pandas as pd
 from es_aws_functions import aws_functions, exception_classes, general_functions
-from marshmallow import Schema, fields, EXCLUDE
+from marshmallow import EXCLUDE, Schema, fields
 
 
 class EnvironmentSchema(Schema):


### PR DESCRIPTION
Moving Marshmallow on from 2.19.5 to 3.6.0 because support for 2.19.5 ends on 18/08/2020.

Updates are fairly straightforward:
Add meta class so that default python variables are excluded from the environment schema check and any extra runtime are kept. (This is incase a lower level call requires the variables but the top level doesn't so we don't lose them. Not greatly applicable here and more for imputation.)

Override the basic Marshmallow Error with out custom one. This moved it out of the main code block and into the Schema itself.