### PR TITLE
Dependancies And Warnings - WIP

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,19 +4,19 @@ appdirs==1.4.3
 asn1crypto==0.24.0
 atomicwrites==1.3.0
 attrs==19.1.0
-aws-sam-translator==1.11.0
+aws-sam-translator==1.24.0
 aws-xray-sdk==2.4.2
-awscli==1.16.179
+awscli==1.18.71
 babel==2.7.0
 backcall==0.1.0
 bandit==1.6.1
 black==19.3b0
-boto3==1.9.169
+boto3==1.13.21
 boto==2.49.0
-botocore==1.12.169
+botocore==1.16.21
 certifi==2019.6.16
 cffi==1.12.3
-cfn-lint==0.21.5
+cfn-lint==0.33.0
 chardet==3.0.4
 click==7.0
 colorama==0.3.9
@@ -44,13 +44,13 @@ ipdb==0.12
 ipython-genutils==0.2.0
 ipython==7.5.0
 jedi==0.13.3
-jinja2==2.10.1
+jinja2==2.11.2
 jmespath==0.9.4
 jsondiff==1.1.2
 jsonpatch==1.23
 jsonpickle==1.2
 jsonpointer==2.0
-jsonschema==2.6.0
+jsonschema==3.2.0
 markupsafe==1.1.1
 marshmallow==3.6.0
 mccabe==0.6.1
@@ -58,7 +58,7 @@ mock==3.0.5
 more-itertools==7.0.0 ; python_version > '2.7'
 moto==1.3.8
 packaging==19.0
-pandas==0.24.2
+pandas==1.0.4
 parso==0.4.0
 pbr==5.3.0
 pep8-naming==0.8.2
@@ -77,13 +77,13 @@ pyparsing==2.4.0
 pytest-cov==2.7.1
 pytest==4.6.3
 python-dateutil==2.8.0
-python-jose==3.0.1
+python-jose==3.1.0
 pytz==2019.1
 pyyaml==5.1 ; python_version != '2.6'
 requests==2.22.0
 responses==0.10.6
 rsa==3.4.2
-s3transfer==0.2.1
+s3transfer==0.3.0
 safety==1.8.5
 six==1.12.0
 smmap2==2.0.5

--- a/tests/test_strata.py
+++ b/tests/test_strata.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 from es_aws_functions import exception_classes, test_generic_library
 from moto import mock_s3
-from pandas.util.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal
 
 import strata_period_method as lambda_method_function
 import strata_period_wrangler as lambda_wrangler_function
@@ -172,13 +172,13 @@ def test_calculate_strata():
         value_column="Q608_total",
         survey_column="survey",
         region_column="region",
-        axis=1,
+        axis=1
     )
     produced_data = produced_data.sort_index(axis=1)
 
     with open("tests/fixtures/test_method_prepared_output.json", "r") as file_2:
         file_data = file_2.read()
-    prepared_data = pd.DataFrame(json.loads(file_data))
+    prepared_data = pd.DataFrame(json.loads(file_data)).sort_index(axis=1)
 
     assert_frame_equal(produced_data, prepared_data)
 
@@ -194,7 +194,7 @@ def test_method_success():
                          method_environment_variables):
         with open("tests/fixtures/test_method_prepared_output.json", "r") as file_1:
             file_data = file_1.read()
-        prepared_data = pd.DataFrame(json.loads(file_data))
+        prepared_data = pd.DataFrame(json.loads(file_data)).sort_index(axis=1)
 
         with open("tests/fixtures/test_method_input.json", "r") as file_2:
             test_data = file_2.read()
@@ -203,7 +203,7 @@ def test_method_success():
         output = lambda_method_function.lambda_handler(
             method_runtime_variables, test_generic_library.context_object)
 
-        produced_data = pd.DataFrame(json.loads(output["data"]))
+        produced_data = pd.DataFrame(json.loads(output["data"])).sort_index(axis=1)
 
     assert output["success"]
     assert_frame_equal(produced_data, prepared_data)
@@ -228,6 +228,7 @@ def test_strata_mismatch_detector():
         "previous_period",
         "current_strata",
         "previous_strata")
+    produced_data = produced_data.sort_index(axis=1)
 
     with open("tests/fixtures/test_wrangler_prepared_output.json", "r") as file_2:
         test_data_out = file_2.read()
@@ -337,7 +338,7 @@ def test_wrangler_success_returned(mock_s3_get, mock_s3_put):
               wrangler_runtime_variables["RuntimeVariables"]["out_file_name"],
               "r") as file_4:
         test_data_produced = file_4.read()
-    produced_data = pd.DataFrame(json.loads(test_data_produced))
+    produced_data = pd.DataFrame(json.loads(test_data_produced)).sort_index(axis=1)
 
     assert output
     assert_frame_equal(produced_data, prepared_data)


### PR DESCRIPTION
Test To See About Upgrading Pandas As Well As Removing As Many Depreciation Warnings As Possible.

All But 1 Warning Removed. Updating Moto To Latest (Which Requires The Following Lines In Test To Work. (
import os
os.environ.setdefault("AWS_ACCESS_KEY_ID", "foobar_key")
os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "foobar_secret")
) Does Not Help.

Some Of The Updated Dependencies Didn't Throw Warnings Or Errors But I Noticed In The Build Print That Some Were Incompatible After Updating And So Had To Follow The Chain Down To Update More.